### PR TITLE
Improve duty date inference to avoid overnight streak false positives

### DIFF
--- a/FTL.py
+++ b/FTL.py
@@ -56,14 +56,64 @@ def infer_common_columns(df):
     df.columns = cols
     pilot_candidates = [c for c in cols if re.search(r"(pilot|crew|user|employee|person|name)", c, re.I)]
     pilot_col = pilot_candidates[0] if pilot_candidates else None
+
+    parsed_cache = {}
+
+    def parsed_series(col):
+        if col is None or col not in df.columns:
+            return pd.Series(pd.NaT, index=df.index, dtype="datetime64[ns]")
+        if col not in parsed_cache:
+            parsed_cache[col] = pd.to_datetime(df[col], errors="coerce", dayfirst=True)
+        return parsed_cache[col]
+
     date_candidates = [c for c in cols if re.search(r"(date|day)", c, re.I)]
+    # Also consider columns that explicitly mention begin/start even if they lack "date"/"day"
+    date_candidates += [c for c in cols if re.search(r"(begin|start|report)", c, re.I)]
+    # Preserve first occurrence order while removing duplicates
+    seen = set()
+    date_candidates = [c for c in date_candidates if not (c in seen or seen.add(c))]
+
+    def date_score(name):
+        lname = name.lower()
+        score = 2
+        if re.search(r"(begin|start|report)", lname):
+            score = 0
+        elif re.search(r"(off|out|dep)", lname):
+            score = 1
+        if re.search(r"(end|arriv|finish|complete|in|release)", lname):
+            score += 3
+        return score, cols.index(name)
+
+    date_candidates = sorted(date_candidates, key=date_score)
+
     date_col = None
     for c in date_candidates:
-        parsed = pd.to_datetime(df[c], errors="coerce", dayfirst=True)
+        parsed = parsed_series(c)
         if parsed.notna().mean() > 0.5:
             date_col = c
             break
-    return pilot_col, date_col
+
+    begin_cols = []
+    end_cols = []
+    for c in cols:
+        lname = c.lower()
+        parsed = parsed_series(c)
+        if parsed.notna().mean() <= 0.2:
+            continue
+        if re.search(r"(begin|start|report|sign\s*in|show)", lname):
+            begin_cols.append(c)
+        elif re.search(r"(end|finish|release|off|arriv|complete)", lname):
+            end_cols.append(c)
+
+    begin_cols = [c for c in begin_cols if c != date_col]
+    end_cols = [c for c in end_cols if c != date_col]
+
+    return {
+        "pilot_col": pilot_col,
+        "date_col": date_col,
+        "begin_cols": begin_cols,
+        "end_cols": end_cols,
+    }
 
 def infer_duty_column(df):
     cols = list(df.columns)
@@ -223,22 +273,63 @@ def streaks(df, flag_col, min_consecutive=3):
         columns=["Pilot", "StartDate", "EndDate", "ConsecutiveDays"]
     )
 
-def build_duty_table(df, pilot_col, date_col, duty_col, min_hours=12.0):
+def _coalesce_datetime_columns(df, primary_col, fallback_cols):
+    parsed_cache = {}
+
+    def parsed(col):
+        if col is None or col not in df.columns:
+            return pd.Series(pd.NaT, index=df.index, dtype="datetime64[ns]")
+        if col not in parsed_cache:
+            parsed_cache[col] = pd.to_datetime(df[col], errors="coerce", dayfirst=True)
+        return parsed_cache[col]
+
+    series = parsed(primary_col)
+    if fallback_cols:
+        combined = pd.Series(pd.NaT, index=df.index, dtype="datetime64[ns]")
+        for col in fallback_cols:
+            combined = combined.combine_first(parsed(col))
+        series = combined.combine_first(series)
+    return series
+
+
+def _normalize_dates(series):
+    if series.empty:
+        return series
+    dtype = series.dtype
+    if hasattr(dtype, "tz") and dtype.tz is not None:
+        try:
+            series = series.dt.tz_convert(None)
+        except TypeError:
+            series = series.dt.tz_localize(None)
+    return series.dt.floor("D")
+
+
+def build_duty_table(df, pilot_col, date_col, duty_col, min_hours=12.0, begin_cols=None):
+    df = df.copy()
     df[pilot_col] = df[pilot_col].ffill()
-    work = df[[pilot_col, date_col, duty_col]].copy()
-    work.columns = ["Pilot", "Date", "DutyRaw"]
-    work["Date"] = pd.to_datetime(work["Date"], errors="coerce", dayfirst=True)
+
+    begin_cols = begin_cols or []
+    date_series = _coalesce_datetime_columns(df, date_col, begin_cols)
+
+    work = pd.DataFrame({
+        "Pilot": df[pilot_col],
+        "Date": date_series,
+        "DutyRaw": df[duty_col],
+    })
+
     work["DutyHours"] = work["DutyRaw"].map(parse_duration_to_hours)
     work = work.dropna(subset=["Pilot", "Date", "DutyHours"])
+    work["Date"] = _normalize_dates(work["Date"])
     work = work.sort_values(["Pilot", "Date"]).groupby(["Pilot", "Date"], as_index=False)["DutyHours"].max()
     work["LongDuty"] = work["DutyHours"] >= float(min_hours)
     return work
 
 def build_rest_table(df, pilot_col, date_col, rest_col, short_thresh=11.0):
+    df = df.copy()
     df[pilot_col] = df[pilot_col].ffill()
     rest = df[[pilot_col, date_col, rest_col]].copy()
     rest.columns = ["Pilot", "Date", "RestRaw"]
-    rest["Date"] = pd.to_datetime(rest["Date"], errors="coerce", dayfirst=True)
+    rest["Date"] = _normalize_dates(pd.to_datetime(rest["Date"], errors="coerce", dayfirst=True))
     rest["RestHours"] = rest["RestRaw"].map(parse_duration_to_hours)
     rest = rest.dropna(subset=["Pilot", "Date", "RestHours"])
     rest = rest.sort_values(["Pilot", "Date"]).groupby(["Pilot", "Date"], as_index=False)["RestHours"].min()
@@ -273,7 +364,9 @@ with tab_results:
         st.info("Upload the **FTL CSV** in the sidebar to run Duty Streaks and Short Rest checks.")
     else:
         df = try_read_csv(ftl_file)
-        pilot_col, date_col = infer_common_columns(df.copy())
+        common_cols = infer_common_columns(df.copy())
+        pilot_col = common_cols.get("pilot_col")
+        date_col = common_cols.get("date_col")
 
         if not pilot_col or not date_col:
             st.error("Could not confidently identify common columns (Pilot, Date) in the FTL CSV.")
@@ -287,7 +380,14 @@ with tab_results:
             else:
                 duty_work = None; rest_work = None
                 if duty_col:
-                    duty_work = build_duty_table(df.copy(), pilot_col, date_col, duty_col, min_hours=12.0)
+                    duty_work = build_duty_table(
+                        df.copy(),
+                        pilot_col,
+                        date_col,
+                        duty_col,
+                        min_hours=12.0,
+                        begin_cols=common_cols.get("begin_cols"),
+                    )
                     seq2_duty = streaks(duty_work, "LongDuty", min_consecutive=2)
                     seq3_duty = streaks(duty_work, "LongDuty", min_consecutive=3)
                 if rest_col:


### PR DESCRIPTION
## Summary
- collect begin/report date columns during FTL CSV inference and feed them into duty-day construction
- normalize duty-day dates so overnight duties ending after midnight do not count as extra calendar days

## Testing
- python -m compileall FTL.py

------
https://chatgpt.com/codex/tasks/task_e_68dffd654eb88333bcb7c2b78de333bb