### PR TITLE
Fix indentation error in date score logic

### DIFF
--- a/FTL.py
+++ b/FTL.py
@@ -81,7 +81,6 @@ def infer_common_columns(df):
         elif re.search(r"(off|out|dep)", lname):
             score = 1
         if re.search(r"(end|arriv|finish|complete|in|release)", lname):
-        if re.search(r"(end|arriv|finish|complete|in)", lname):
             score += 3
         return score, cols.index(name)
 


### PR DESCRIPTION
## Summary
- remove stray duplicate conditional in the date column scoring helper to restore valid indentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00f5ed42c83339a1432b5acff5be1